### PR TITLE
Fix a issue of "Re-opens Firefox when rebuilding"

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ WebpackWebExt.prototype.runWebExtCommand = function() {
 
 WebpackWebExt.prototype.apply = function(compiler) {
   compiler.plugin('emit', (compilation, callback) => {
-    if (this.runOnce && !this.webExtRunPromise) {
+    if (this.runOnce) {
       if (!this.webExtRunPromise) {
         this.webExtRunPromise = this.runWebExtCommand();
       }


### PR DESCRIPTION
#1

Even if I set runOnce = true, firefox instance pops up each rebuilding process.
This PR fixes the issue.

Example webpack.config.js is here.
```
const WebpackWebExt = require('webpack-webext-plugin');

module.exports = {
...
  plugins: [
    new WebpackWebExt({
      runOnce: false,
      argv: ["lint", "-s", "src"],
    }),
    new WebpackWebExt({
      runOnce: true,
      maxRetries: 0,
      argv: ["run", "-s", "addon/"],
    })
  ]
};
```